### PR TITLE
Consume the reusable workflows from upbound/uptest@standard-runners

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   backport:
-    uses: upbound/uptest/.github/workflows/provider-backport.yml@main
+    uses: upbound/uptest/.github/workflows/provider-backport.yml@standard-runners

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ci:
-    uses: upbound/uptest/.github/workflows/provider-ci.yml@main
+    uses: upbound/uptest/.github/workflows/provider-ci.yml@standard-runners
     with:
       go-version: 1.21
     secrets:

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -4,4 +4,4 @@ on: issue_comment
 
 jobs:
   comment-commands:
-    uses: upbound/uptest/.github/workflows/provider-commands.yml@main
+    uses: upbound/uptest/.github/workflows/provider-commands.yml@standard-runners

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   e2e:
-    uses: upbound/uptest/.github/workflows/pr-comment-trigger.yml@main
+    uses: upbound/uptest/.github/workflows/pr-comment-trigger.yml@standard-runners
     with:
       go-version: 1.21
     secrets:

--- a/.github/workflows/issue_triage.yml
+++ b/.github/workflows/issue_triage.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   community-issue-triage:
-    uses: upbound/uptest/.github/workflows/issue-triage.yml@main
+    uses: upbound/uptest/.github/workflows/issue-triage.yml@standard-runners
     secrets:
       UPBOUND_BOT_GITHUB_TOKEN: ${{ secrets.UPBOUND_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/native-provider-bump.yml
+++ b/.github/workflows/native-provider-bump.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   open-bump-pr:
-    uses: upbound/uptest/.github/workflows/native-provider-bump.yml@main
+    uses: upbound/uptest/.github/workflows/native-provider-bump.yml@standard-runners
     with:
       provider-source: hashicorp/azuread
       go-version: 1.21

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -40,7 +40,7 @@ jobs:
           echo "We are going to scan the last ${supported_releases_number} releases for: ${images}"
 
   scan:
-    uses: upbound/uptest/.github/workflows/scan.yml@main
+    uses: upbound/uptest/.github/workflows/scan.yml@standard-runners
     needs:
       - setup-vars
     with:

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   tag:
-    uses: upbound/uptest/.github/workflows/provider-tag.yml@main
+    uses: upbound/uptest/.github/workflows/provider-tag.yml@standard-runners
     with:
       version: ${{ github.event.inputs.version }}
       message: ${{ github.event.inputs.message }}

--- a/.github/workflows/updoc.yml
+++ b/.github/workflows/updoc.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-docs:
-    uses: upbound/uptest/.github/workflows/provider-updoc.yml@main
+    uses: upbound/uptest/.github/workflows/provider-updoc.yml@standard-runners
     with:
       go-version: 1.21
     secrets:


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azuread Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azuread Provider pull request. Find us in https://crossplane.slack.com/archives/C01TRKD4623 if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azuread Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Relevant PR: https://github.com/upbound/uptest/pull/184

The `uptest`, `lint` & `publish-artifacts` jobs are [currently failing](https://github.com/crossplane-contrib/provider-upjet-azuread/pull/105) because they are assigned to runners that are unavailable for this organization. This PR switches them to the standard runners.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
The PR pipeline (from the `upbound/uptest/.github/workflows/provider-ci.yml` reusable workflow) has been tested with this PR. Unfortunately, the `e2e` pipeline (which runs `uptest`) will be tested once these changes are in the main branch (in #105). 
