### PR TITLE
[Backport release-0.15] Update alpine Docker tag to v3.19.1

### DIFF
--- a/cluster/images/provider-azuread/Dockerfile
+++ b/cluster/images/provider-azuread/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18.5
+FROM alpine:3.19.1
 RUN apk --no-cache add ca-certificates bash
 
 ARG TARGETOS


### PR DESCRIPTION
# Description
Backport of #92 to `release-0.15`.