### PR TITLE
Bump crossplane-runtime version to consume the fix of MR metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ toolchain go1.21.8
 
 require (
 	dario.cat/mergo v1.0.0
-	github.com/crossplane/crossplane-runtime v1.16.0-rc.1.0.20240424114634-8641eb2ba384
+	github.com/crossplane/crossplane-runtime v1.16.0-rc.2.0.20240510094504-3f697876fa57
 	github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79
 	github.com/crossplane/upjet v1.4.0-rc.0.0.20240508134714-03a207b6416a
 	github.com/hashicorp/terraform-json v0.17.1

--- a/go.sum
+++ b/go.sum
@@ -696,8 +696,8 @@ github.com/cncf/xds/go v0.0.0-20230105202645-06c439db220b/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane-runtime v1.16.0-rc.1.0.20240424114634-8641eb2ba384 h1:EswfDIEITA16CUWt78dVN0plbMBk8TdDfpbVXNeQJ1Y=
-github.com/crossplane/crossplane-runtime v1.16.0-rc.1.0.20240424114634-8641eb2ba384/go.mod h1:Pz2tdGVMF6KDGzHZOkvKro0nKc8EzK0sb/nSA7pH4Dc=
+github.com/crossplane/crossplane-runtime v1.16.0-rc.2.0.20240510094504-3f697876fa57 h1:728dBhd/xm0Wv3g/BtoT90tMTvV6aY45QVRnNCCWJ/g=
+github.com/crossplane/crossplane-runtime v1.16.0-rc.2.0.20240510094504-3f697876fa57/go.mod h1:Pz2tdGVMF6KDGzHZOkvKro0nKc8EzK0sb/nSA7pH4Dc=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79 h1:HigXs5tEQxWz0fcj8hzbU2UAZgEM7wPe0XRFOsrtF8Y=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79/go.mod h1:+e4OaFlOcmr0JvINHl/yvEYBrZawzTgj6pQumOH1SS0=
 github.com/crossplane/upjet v1.4.0-rc.0.0.20240508134714-03a207b6416a h1:VSpJnOWhWPz0sc9Qnp1st7jC49h8r4E9VYKi379I0lY=


### PR DESCRIPTION
### Description of your changes

This PR bumps crossplane-runtime version to consume the fix of MR metrics. Please see the reference PR: https://github.com/crossplane/crossplane-runtime/pull/688

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
Via uptest: https://github.com/crossplane-contrib/provider-upjet-azuread/actions/runs/9094237569

[contribution process]: https://git.io/fj2m9
