### PR TITLE
Only apply CRD API conversions for converting between singleton list and embedded objects APIs

### DIFF
--- a/config/old-singleton-list-apis.txt
+++ b/config/old-singleton-list-apis.txt
@@ -1,0 +1,6 @@
+azuread_application
+azuread_conditional_access_policy
+azuread_group
+azuread_invitation
+azuread_named_location
+azuread_service_principal

--- a/config/provider.go
+++ b/config/provider.go
@@ -6,9 +6,12 @@ package config
 
 import (
 	"context"
+	"strings"
+
 	// Note(turkenh): we are importing this to embed provider schema document
 	_ "embed"
 
+	"github.com/crossplane/upjet/pkg/config"
 	ujconfig "github.com/crossplane/upjet/pkg/config"
 	"github.com/crossplane/upjet/pkg/config/conversion"
 	"github.com/crossplane/upjet/pkg/registry/reference"
@@ -43,6 +46,28 @@ var providerSchema string
 
 //go:embed provider-metadata.yaml
 var providerMetadata string
+
+// oldSingletonListAPIs is a newline-delimited list of Terraform resource
+// names with converted singleton list APIs with at least CRD API version
+// containing the old singleton list API. This is to prevent the API
+// conversion for the newly added resources whose CRD APIs will already
+// use embedded objects instead of the singleton lists and thus, will
+// not possess a CRD API version with the singleton list. Thus, for
+// the newly added resources (resources added after the singleton lists
+// have been converted), we do not need the CRD API conversion
+// functions that convert between singleton lists and embedded objects,
+// but we need only the Terraform conversion functions.
+// This list is immutable and represents the set of resources with the
+// already generated CRD API versions with now converted singleton lists.
+// Because new resources should never have singleton lists in their
+// generated APIs, there should be no need to add them to this list.
+// However, bugs might result in exceptions in the future.
+// Please see:
+// https://github.com/crossplane-contrib/provider-upjet-azuread/pull/123
+// for more context on singleton list to embedded object conversions.
+//
+//go:embed old-singleton-list-apis.txt
+var oldSingletonListAPIs string
 
 // workaround for the TF Google v2.41.0-based no-fork release: We would like to
 // keep the types in the generated CRDs intact
@@ -136,6 +161,12 @@ func resourceList(t map[string]ujconfig.ExternalName) []string {
 }
 
 func bumpVersionsWithEmbeddedLists(pc *ujconfig.Provider) {
+	l := strings.Split(strings.TrimSpace(oldSingletonListAPIs), "\n")
+	oldSLAPIs := make(map[string]struct{}, len(l))
+	for _, n := range l {
+		oldSLAPIs[n] = struct{}{}
+	}
+
 	for name, r := range pc.Resources {
 		r := r
 		// nothing to do if no singleton list has been converted to
@@ -143,15 +174,28 @@ func bumpVersionsWithEmbeddedLists(pc *ujconfig.Provider) {
 		if len(r.CRDListConversionPaths()) == 0 {
 			continue
 		}
-		r.Version = "v1beta2"
-		// we would like to set the storage version to v1beta1 to facilitate
-		// downgrades.
-		r.SetCRDStorageVersion("v1beta1")
-		r.ControllerReconcileVersion = "v1beta1"
-		r.Conversions = []conversion.Conversion{
-			conversion.NewIdentityConversionExpandPaths(conversion.AllVersions, conversion.AllVersions, []string{"spec.forProvider", "spec.initProvider", "status.atProvider"}, r.CRDListConversionPaths()...),
-			conversion.NewSingletonListConversion("v1beta1", "v1beta2", conversion.DefaultPathPrefixes(), r.CRDListConversionPaths(), conversion.ToEmbeddedObject),
-			conversion.NewSingletonListConversion("v1beta2", "v1beta1", conversion.DefaultPathPrefixes(), r.CRDListConversionPaths(), conversion.ToSingletonList)}
+		if _, ok := oldSLAPIs[name]; ok {
+			r.Version = "v1beta2"
+			r.PreviousVersions = []string{"v1beta1"}
+			// we would like to set the storage version to v1beta1 to facilitate
+			// downgrades.
+			r.SetCRDStorageVersion("v1beta1")
+			// because the controller reconciles on the API version with the singleton list API,
+			// no need for a Terraform conversion.
+			r.ControllerReconcileVersion = "v1beta1"
+			r.Conversions = []conversion.Conversion{
+				conversion.NewIdentityConversionExpandPaths(conversion.AllVersions, conversion.AllVersions, conversion.DefaultPathPrefixes(), r.CRDListConversionPaths()...),
+				conversion.NewSingletonListConversion("v1beta1", "v1beta2", conversion.DefaultPathPrefixes(), r.CRDListConversionPaths(), conversion.ToEmbeddedObject),
+				conversion.NewSingletonListConversion("v1beta2", "v1beta1", conversion.DefaultPathPrefixes(), r.CRDListConversionPaths(), conversion.ToSingletonList)}
+		} else {
+			// the controller will be reconciling on the CRD API version
+			// with the converted API (with embedded objects in place of
+			// singleton lists), so we need the appropriate Terraform
+			// converter in this case.
+			r.TerraformConversions = []config.TerraformConversion{
+				config.NewTFSingletonConversion(),
+			}
+		}
 		pc.Resources[name] = r
 	}
 }


### PR DESCRIPTION
### Description of your changes

Only apply the CRD API conversions for converting between singleton list & embedded object APIs for the already existing resources with the generated singleton list CRD APIs.

When we try to add a new Terraform resource with a singleton list in its schema, currently, we need to do a manual configuration such as the following:
```go
p.AddResourceConfigurator("azurerm_pim_active_role_assignment", func(r *config.Resource) {
		r.PreviousVersions = nil
		r.Version = "v1beta1"
		r.Conversions = nil
		r.TerraformConversions = []config.TerraformConversion{
			config.NewTFSingletonConversion(),
		}
	})
```
, so that the API converters registered are removed and versioning starts with `v1beta1` instead of `v1beta2` (for such new resources, the `v1beta1` version does not already exist).

This PR records the names of resources with previous CRD APIs containing (now converted) singleton lists so that the API converters are only registered for them.
This makes adding new resources with singleton lists in their Terraform schemas easier by removing the need to do a manual configuration like shown above.

The newly introduced list should mostly be immutable (it records a set of existing resources with a specific condition at a point in time). Bugs may result in exceptions where we may need to update this list. In other words, new resources should normally be never added to this list, doing so will result in an invalid configuration.

Counterpart PR: https://github.com/crossplane-contrib/provider-upjet-azure/pull/767

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

Uptest: https://github.com/crossplane-contrib/provider-upjet-azuread/actions/runs/10056972531

[contribution process]: https://git.io/fj2m9
