### PR TITLE
Fix Example in Permissiongrant Managed Resource

### DIFF
--- a/examples/serviceprincipaldelegated/v1beta1/permissiongrant.yaml
+++ b/examples/serviceprincipaldelegated/v1beta1/permissiongrant.yaml
@@ -19,10 +19,9 @@ spec:
       matchLabels:
         testing.upbound.io/example-name: msgraph
     claimValues:
-        # Id obtained from status.atProvider.oauth2PermissionScopeIds["openid"] from the Principal(msgraph) resource below.
-      - 37f7f235-527c-4136-accd-4a02d197296e
-        # Id obtained from status.atProvider.oauth2PermissionScopeIds["User.Read.All"] from the Principal(msgraph) resource below.
-      - a154be20-db9c-4678-8ab7-66f6cc099a59
+        # These claim match the permission names in the requiredResourceAccess of the Application resource below.
+      - openid
+      - User.Read
 ---
 apiVersion: serviceprincipals.azuread.upbound.io/v1beta1
 kind: Principal


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azuread Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azuread Provider pull request. Find us in https://crossplane.slack.com 
if you need any help contributing.
-->

### Description of your changes

This PR fixes the claimValues example in the PermissionGrant AzureAD provider.

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azuread Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes N/A

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Checking Terraform official [documentation](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal_delegated_permission_grant#claim_values) we can observe there is a mistake in the example: 

![image](https://github.com/user-attachments/assets/105c9af6-0334-4e97-b3fc-376bf5bba389)

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
