### PR TITLE
Update build submodule and set XPKG_CLEANUP_EXAMPLES_ENABLED = true

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,8 @@ XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.upbound.io/upbound
 XPKGS = $(PROJECT_NAME)
 XPKG_DIR = $(OUTPUT_DIR)/package
 XPKG_IGNORE = kustomize/*,crds/kustomization.yaml
+# Set to true to enable the cleanup examples step in the build process
+XPKG_CLEANUP_EXAMPLES_ENABLED = true
 
 -include build/makelib/xpkg.mk
 


### PR DESCRIPTION
### Description of your changes

This PR updates build submodule and sets `XPKG_CLEANUP_EXAMPLES_ENABLED = true`

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

Manually tested with `index.docker.io/turkenf/provider-azuread:v1.6.0-rc.0.6.ga757eaa`

[contribution process]: https://git.io/fj2m9
