### PR TITLE
Ignore lateinitialize for owner field in group resource

### DIFF
--- a/apis/groups/v1beta1/zz_group_terraformed.go
+++ b/apis/groups/v1beta1/zz_group_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Group) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("Owners"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/groups/v1beta2/zz_group_terraformed.go
+++ b/apis/groups/v1beta2/zz_group_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Group) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("Owners"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/groups/config.go
+++ b/config/groups/config.go
@@ -12,6 +12,9 @@ func Configure(p *config.Provider) {
 		// We need to override the default group that upjet generated for
 		// this resource, which would be "azuread"
 		r.ShortGroup = "groups"
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"owners"},
+		}
 	})
 	p.AddResourceConfigurator("azuread_group_member", func(r *config.Resource) {
 		r.References["group_object_id"] = config.Reference{


### PR DESCRIPTION
### Description of your changes

This PR ignores late-initialize for owner field in group resource to avoid 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

Uptest: https://github.com/crossplane-contrib/provider-upjet-azuread/actions/runs/11683308033

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
