### PR TITLE
Prevent member from triggering workflow via PR comment

### DIFF
--- a/.github/workflows/uptest-trigger.yaml
+++ b/.github/workflows/uptest-trigger.yaml
@@ -22,7 +22,7 @@ jobs:
           echo "github.event.comment.author_association: ${{ github.event.comment.author_association }}"
 
   get-example-list:
-    if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' ) &&
+    if: ${{ (github.event.comment.author_association == 'OWNER' ) &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '/test-examples' ) }}
     runs-on: ubuntu-latest
@@ -79,7 +79,7 @@ jobs:
             -f context="Uptest-${{ steps.get-example-list-name.outputs.example-hash }}"
 
   uptest:
-    if: ${{ (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' ) &&
+    if: ${{ (github.event.comment.author_association == 'OWNER' ) &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '/test-examples' ) }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description of your changes

Prevents member from triggering workflow via PR comment

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
