### PR TITLE
[Group] Set crossplane.io/external-name annotation

### DIFF
--- a/apis/groups/v1beta1/zz_group_terraformed.go
+++ b/apis/groups/v1beta1/zz_group_terraformed.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/crossplane/upjet/pkg/resource"
 	"github.com/crossplane/upjet/pkg/resource/json"
+
+  "github.com/crossplane/crossplane-runtime/pkg/meta"
 )
 
 // GetTerraformResourceType returns Terraform resource type for this Group
@@ -127,4 +129,13 @@ func (tr *Group) LateInitialize(attrs []byte) (bool, error) {
 // GetTerraformSchemaVersion returns the associated Terraform schema version
 func (tr *Group) GetTerraformSchemaVersion() int {
 	return 0
+}
+
+// SetExternalName ensures the external name annotation is set from the provider's object ID after creation.
+func (tr *Group) SetExternalName() {
+	if tr.Status.AtProvider.ID != nil && *tr.Status.AtProvider.ID != "" {
+		meta.SetExternalName(tr, *tr.Status.AtProvider.ID)
+	} else if tr.Status.AtProvider.ObjectID != nil && *tr.Status.AtProvider.ObjectID != "" {
+		meta.SetExternalName(tr, *tr.Status.AtProvider.ObjectID)
+	}
 }

--- a/apis/groups/v1beta2/zz_group_terraformed.go
+++ b/apis/groups/v1beta2/zz_group_terraformed.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/crossplane/upjet/pkg/resource"
 	"github.com/crossplane/upjet/pkg/resource/json"
+
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 )
 
 // GetTerraformResourceType returns Terraform resource type for this Group
@@ -127,4 +129,13 @@ func (tr *Group) LateInitialize(attrs []byte) (bool, error) {
 // GetTerraformSchemaVersion returns the associated Terraform schema version
 func (tr *Group) GetTerraformSchemaVersion() int {
 	return 0
+}
+
+// SetExternalName ensures the external name annotation is set from the provider's object ID after creation.
+func (tr *Group) SetExternalName() {
+	if tr.Status.AtProvider.ID != nil && *tr.Status.AtProvider.ID != "" {
+		meta.SetExternalName(tr, *tr.Status.AtProvider.ID)
+	} else if tr.Status.AtProvider.ObjectID != nil && *tr.Status.AtProvider.ObjectID != "" {
+		meta.SetExternalName(tr, *tr.Status.AtProvider.ObjectID)
+	}
 }


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->
Fixes #159

After hitting the same issue as #159 noticed that `crossplane.io/external-name annotation` is not being set after the Group becomes ready. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

I managed to deploy this locally in a kind cluster:
- deployed a group and watched it to be created
- confirmed the annotation is set properly
- restarted the controller and confirmed that it is not creating the group again

group:
```yaml
piVersion: groups.azuread.upbound.io/v1beta1
kind: Group
metadata:
  annotations:
    crossplane.io/external-create-pending: '2025-05-06T02:49:20Z'
    crossplane.io/external-create-succeeded: '2025-05-06T02:49:20Z'
    crossplane.io/external-name: 6a01c7d9-dc50-4b5c-bb3a-574c215e62af
    kubectl.kubernetes.io/last-applied-configuration: >
      {"apiVersion":"groups.azuread.upbound.io/v1beta2","kind":"Group","metadata":{"annotations":{},"name":"pj-test-3"},"spec":{"forProvider":{"displayName":"PJ
      Test
      2","members":["7e225877-3851-4532-8bc3-1e0ef5bffd3a"],"securityEnabled":true},"managementPolicies":["*"]}}
{redacted}
```

controller logs after restart:
```
2025-05-06T03:10:54Z	DEBUG	provider-azuread	Starting	{"sync-period": "1h0m0s", "poll-interval": "10m0s", "poll-jitter": "30s", "max-reconcile-rate": 10}
2025-05-06T03:10:54Z	INFO	provider-azuread	Beta feature enabled	{"flag": "EnableBetaManagementPolicies"}
2025-05-06T03:10:54Z	DEBUG	provider-azuread	Calling the inner handler for Create event.	{"gvk": "groups.azuread.upbound.io/v1beta1, Kind=Group", "name": "pj-test-3", "queueLength": 0}
2025-05-06T03:10:54Z	DEBUG	provider-azuread	Reconciling	{"controller": "managed/groups.azuread.upbound.io/v1beta1, kind=group", "request": {"name":"pj-test-3"}}
2025-05-06T03:10:54Z	DEBUG	provider-azuread	Connecting to the service provider	{"uid": "d0d741a2-f9f8-4acf-8cd2-1037f666ef3b", "name": "pj-test-3", "gvk": "groups.azuread.upbound.io/v1beta1, Kind=Group"}
2025-05-06T03:10:54Z	DEBUG	provider-azuread	Reconciling	{"controller": "providerconfig/providerconfig.azuread.upbound.io", "request": {"name":"default"}}
2025-05-06T03:10:54Z	DEBUG	provider-azuread	Reconciling	{"controller": "providerconfig/providerconfig.azuread.upbound.io", "request": {"name":"default"}}
2025-05-06T03:10:54Z	DEBUG	provider-azuread	Instance state not found in cache, reconstructing...	{"uid": "d0d741a2-f9f8-4acf-8cd2-1037f666ef3b", "name": "pj-test-3", "gvk": "groups.azuread.upbound.io/v1beta1, Kind=Group"}
2025-05-06T03:10:54Z	DEBUG	provider-azuread	Observing the external resource	{"uid": "d0d741a2-f9f8-4acf-8cd2-1037f666ef3b", "name": "pj-test-3", "gvk": "groups.azuread.upbound.io/v1beta1, Kind=Group"}
2025-05-06T03:10:55Z	DEBUG	provider-azuread	External resource is up to date	{"controller": "managed/groups.azuread.upbound.io/v1beta1, kind=group", "request": {"name":"pj-test-3"}, "uid": "d0d741a2-f9f8-4acf-8cd2-1037f666ef3b", "version": "7957", "external-name": "5dea46a0-dd60-4f85-8e97-f6ed3475038c", "requeue-after": "2025-05-06T03:20:37Z"}
```

[contribution process]: https://git.io/fj2m9
