### PR TITLE
build: pass robot token credentials to publishing to mirror registry

### DIFF
--- a/.github/workflows/publish-provider-package.yaml
+++ b/.github/workflows/publish-provider-package.yaml
@@ -22,4 +22,5 @@ jobs:
       cleanup-disk: true
     secrets:
       GHCR_PAT: ${{ secrets.GITHUB_TOKEN }}
-      XPKG_UPBOUND_TOKEN: ${{ secrets.XPKG_UPBOUND_TOKEN }}
+      XPKG_MIRROR_TOKEN: ${{ secrets.XPKG_TOKEN }}
+      XPKG_MIRROR_ACCESS_ID: ${{ secrets.XPKG_ACCESS_ID }}


### PR DESCRIPTION
### Description of your changes

This PR updates the publishing workflow to pass the correct robot credentials.

Fixes https://github.com/crossplane-contrib/provider-upjet-azuread/actions/runs/15732652091
Ref: https://github.com/crossplane-contrib/provider-kubernetes/pull/368

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

https://github.com/crossplane-contrib/provider-kubernetes/actions/runs/15702494449

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
