### PR TITLE
Add extractors for ref fields in the app RoleAssignment resource

### DIFF
--- a/apis/cluster/app/v1beta1/zz_generated.resolvers.go
+++ b/apis/cluster/app/v1beta1/zz_generated.resolvers.go
@@ -8,6 +8,7 @@ package v1beta1
 import (
 	"context"
 	reference "github.com/crossplane/crossplane-runtime/v2/pkg/reference"
+	resource "github.com/crossplane/upjet/v2/pkg/resource"
 	errors "github.com/pkg/errors"
 	v1beta2 "github.com/upbound/provider-azuread/apis/cluster/serviceprincipals/v1beta2"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,7 +23,7 @@ func (mg *RoleAssignment) ResolveReferences(ctx context.Context, c client.Reader
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.PrincipalObjectID),
-		Extract:      reference.ExternalName(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.ForProvider.PrincipalObjectIDRef,
 		Selector:     mg.Spec.ForProvider.PrincipalObjectIDSelector,
@@ -39,7 +40,7 @@ func (mg *RoleAssignment) ResolveReferences(ctx context.Context, c client.Reader
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ResourceObjectID),
-		Extract:      reference.ExternalName(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.ForProvider.ResourceObjectIDRef,
 		Selector:     mg.Spec.ForProvider.ResourceObjectIDSelector,
@@ -56,7 +57,7 @@ func (mg *RoleAssignment) ResolveReferences(ctx context.Context, c client.Reader
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.PrincipalObjectID),
-		Extract:      reference.ExternalName(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.InitProvider.PrincipalObjectIDRef,
 		Selector:     mg.Spec.InitProvider.PrincipalObjectIDSelector,
@@ -73,7 +74,7 @@ func (mg *RoleAssignment) ResolveReferences(ctx context.Context, c client.Reader
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.ResourceObjectID),
-		Extract:      reference.ExternalName(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.InitProvider.ResourceObjectIDRef,
 		Selector:     mg.Spec.InitProvider.ResourceObjectIDSelector,

--- a/apis/cluster/app/v1beta1/zz_roleassignment_types.go
+++ b/apis/cluster/app/v1beta1/zz_roleassignment_types.go
@@ -22,6 +22,7 @@ type RoleAssignmentInitParameters struct {
 	// The object ID of the user, group or service principal to be assigned this app role. Supported object types are Users, Groups or Service Principals. Changing this forces a new resource to be created.
 	// The object ID of the user, group or service principal to be assigned this app role
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/cluster/serviceprincipals/v1beta2.Principal
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	PrincipalObjectID *string `json:"principalObjectId,omitempty" tf:"principal_object_id,omitempty"`
 
 	// Reference to a Principal in serviceprincipals to populate principalObjectId.
@@ -35,6 +36,7 @@ type RoleAssignmentInitParameters struct {
 	// The object ID of the service principal representing the resource. Changing this forces a new resource to be created.
 	// The object ID of the service principal representing the resource
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/cluster/serviceprincipals/v1beta2.Principal
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	ResourceObjectID *string `json:"resourceObjectId,omitempty" tf:"resource_object_id,omitempty"`
 
 	// Reference to a Principal in serviceprincipals to populate resourceObjectId.
@@ -85,6 +87,7 @@ type RoleAssignmentParameters struct {
 	// The object ID of the user, group or service principal to be assigned this app role. Supported object types are Users, Groups or Service Principals. Changing this forces a new resource to be created.
 	// The object ID of the user, group or service principal to be assigned this app role
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/cluster/serviceprincipals/v1beta2.Principal
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	// +kubebuilder:validation:Optional
 	PrincipalObjectID *string `json:"principalObjectId,omitempty" tf:"principal_object_id,omitempty"`
 
@@ -99,6 +102,7 @@ type RoleAssignmentParameters struct {
 	// The object ID of the service principal representing the resource. Changing this forces a new resource to be created.
 	// The object ID of the service principal representing the resource
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/cluster/serviceprincipals/v1beta2.Principal
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	// +kubebuilder:validation:Optional
 	ResourceObjectID *string `json:"resourceObjectId,omitempty" tf:"resource_object_id,omitempty"`
 

--- a/apis/namespaced/app/v1beta1/zz_generated.resolvers.go
+++ b/apis/namespaced/app/v1beta1/zz_generated.resolvers.go
@@ -8,6 +8,7 @@ package v1beta1
 import (
 	"context"
 	reference "github.com/crossplane/crossplane-runtime/v2/pkg/reference"
+	resource "github.com/crossplane/upjet/v2/pkg/resource"
 	errors "github.com/pkg/errors"
 	v1beta1 "github.com/upbound/provider-azuread/apis/namespaced/serviceprincipals/v1beta1"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,7 +23,7 @@ func (mg *RoleAssignment) ResolveReferences(ctx context.Context, c client.Reader
 
 	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.PrincipalObjectID),
-		Extract:      reference.ExternalName(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.ForProvider.PrincipalObjectIDRef,
 		Selector:     mg.Spec.ForProvider.PrincipalObjectIDSelector,
@@ -39,7 +40,7 @@ func (mg *RoleAssignment) ResolveReferences(ctx context.Context, c client.Reader
 
 	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ResourceObjectID),
-		Extract:      reference.ExternalName(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.ForProvider.ResourceObjectIDRef,
 		Selector:     mg.Spec.ForProvider.ResourceObjectIDSelector,
@@ -56,7 +57,7 @@ func (mg *RoleAssignment) ResolveReferences(ctx context.Context, c client.Reader
 
 	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.PrincipalObjectID),
-		Extract:      reference.ExternalName(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.InitProvider.PrincipalObjectIDRef,
 		Selector:     mg.Spec.InitProvider.PrincipalObjectIDSelector,
@@ -73,7 +74,7 @@ func (mg *RoleAssignment) ResolveReferences(ctx context.Context, c client.Reader
 
 	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.ResourceObjectID),
-		Extract:      reference.ExternalName(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.InitProvider.ResourceObjectIDRef,
 		Selector:     mg.Spec.InitProvider.ResourceObjectIDSelector,

--- a/apis/namespaced/app/v1beta1/zz_roleassignment_types.go
+++ b/apis/namespaced/app/v1beta1/zz_roleassignment_types.go
@@ -23,6 +23,7 @@ type RoleAssignmentInitParameters struct {
 	// The object ID of the user, group or service principal to be assigned this app role. Supported object types are Users, Groups or Service Principals. Changing this forces a new resource to be created.
 	// The object ID of the user, group or service principal to be assigned this app role
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/namespaced/serviceprincipals/v1beta1.Principal
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	PrincipalObjectID *string `json:"principalObjectId,omitempty" tf:"principal_object_id,omitempty"`
 
 	// Reference to a Principal in serviceprincipals to populate principalObjectId.
@@ -36,6 +37,7 @@ type RoleAssignmentInitParameters struct {
 	// The object ID of the service principal representing the resource. Changing this forces a new resource to be created.
 	// The object ID of the service principal representing the resource
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/namespaced/serviceprincipals/v1beta1.Principal
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	ResourceObjectID *string `json:"resourceObjectId,omitempty" tf:"resource_object_id,omitempty"`
 
 	// Reference to a Principal in serviceprincipals to populate resourceObjectId.
@@ -86,6 +88,7 @@ type RoleAssignmentParameters struct {
 	// The object ID of the user, group or service principal to be assigned this app role. Supported object types are Users, Groups or Service Principals. Changing this forces a new resource to be created.
 	// The object ID of the user, group or service principal to be assigned this app role
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/namespaced/serviceprincipals/v1beta1.Principal
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	// +kubebuilder:validation:Optional
 	PrincipalObjectID *string `json:"principalObjectId,omitempty" tf:"principal_object_id,omitempty"`
 
@@ -100,6 +103,7 @@ type RoleAssignmentParameters struct {
 	// The object ID of the service principal representing the resource. Changing this forces a new resource to be created.
 	// The object ID of the service principal representing the resource
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/namespaced/serviceprincipals/v1beta1.Principal
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	// +kubebuilder:validation:Optional
 	ResourceObjectID *string `json:"resourceObjectId,omitempty" tf:"resource_object_id,omitempty"`
 

--- a/config/cluster/app/config.go
+++ b/config/cluster/app/config.go
@@ -11,9 +11,11 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azuread_app_role_assignment", func(r *config.Resource) {
 		r.References["principal_object_id"] = config.Reference{
 			TerraformName: "azuread_service_principal",
+			Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)`,
 		}
 		r.References["resource_object_id"] = config.Reference{
 			TerraformName: "azuread_service_principal",
+			Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)`,
 		}
 		// We need to override the default group that upjet generated for
 		// this resource, which would be "azuread"

--- a/config/namespaced/app/config.go
+++ b/config/namespaced/app/config.go
@@ -11,9 +11,11 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("azuread_app_role_assignment", func(r *config.Resource) {
 		r.References["principal_object_id"] = config.Reference{
 			TerraformName: "azuread_service_principal",
+			Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)`,
 		}
 		r.References["resource_object_id"] = config.Reference{
 			TerraformName: "azuread_service_principal",
+			Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)`,
 		}
 		// We need to override the default group that upjet generated for
 		// this resource, which would be "azuread"

--- a/examples/cluster/app/v1beta1/roleassignment.yaml
+++ b/examples/cluster/app/v1beta1/roleassignment.yaml
@@ -68,5 +68,5 @@ metadata:
 spec:
   forProvider:
     # I got this id from "data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph"
-    applicationId: 00000003-0000-0000-c000-000000000000
+    clientId: 00000003-0000-0000-c000-000000000000
     useExisting: true

--- a/examples/namespaced/app/v1beta1/roleassignment.yaml
+++ b/examples/namespaced/app/v1beta1/roleassignment.yaml
@@ -72,5 +72,5 @@ metadata:
 spec:
   forProvider:
     # I got this id from "data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph"
-    applicationId: 00000003-0000-0000-c000-000000000000
+    clientIdId: 00000003-0000-0000-c000-000000000000
     useExisting: true


### PR DESCRIPTION
### Description of your changes

This PR adds extractors for ref fields in the app RoleAssignment resource
- `resourceObjectId`
- `principalObjectId`

Fixes https://github.com/crossplane-contrib/provider-upjet-azuread/issues/244

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
