### PR TITLE
Add extractors to PrivilegedAccessGroup resources

### DIFF
--- a/apis/cluster/identitygovernance/v1beta1/zz_generated.resolvers.go
+++ b/apis/cluster/identitygovernance/v1beta1/zz_generated.resolvers.go
@@ -24,7 +24,7 @@ func (mg *PrivilegedAccessGroupAssignmentSchedule) ResolveReferences(ctx context
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.GroupID),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.ForProvider.GroupIDRef,
 		Selector:     mg.Spec.ForProvider.GroupIDSelector,
@@ -58,7 +58,7 @@ func (mg *PrivilegedAccessGroupAssignmentSchedule) ResolveReferences(ctx context
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.GroupID),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.InitProvider.GroupIDRef,
 		Selector:     mg.Spec.InitProvider.GroupIDSelector,
@@ -102,7 +102,7 @@ func (mg *PrivilegedAccessGroupEligibilitySchedule) ResolveReferences(ctx contex
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.GroupID),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.ForProvider.GroupIDRef,
 		Selector:     mg.Spec.ForProvider.GroupIDSelector,
@@ -136,7 +136,7 @@ func (mg *PrivilegedAccessGroupEligibilitySchedule) ResolveReferences(ctx contex
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.GroupID),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.InitProvider.GroupIDRef,
 		Selector:     mg.Spec.InitProvider.GroupIDSelector,

--- a/apis/cluster/identitygovernance/v1beta1/zz_generated.resolvers.go
+++ b/apis/cluster/identitygovernance/v1beta1/zz_generated.resolvers.go
@@ -119,7 +119,7 @@ func (mg *PrivilegedAccessGroupEligibilitySchedule) ResolveReferences(ctx contex
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.PrincipalID),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.ForProvider.PrincipalIDRef,
 		Selector:     mg.Spec.ForProvider.PrincipalIDSelector,
@@ -153,7 +153,7 @@ func (mg *PrivilegedAccessGroupEligibilitySchedule) ResolveReferences(ctx contex
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.PrincipalID),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.InitProvider.PrincipalIDRef,
 		Selector:     mg.Spec.InitProvider.PrincipalIDSelector,

--- a/apis/cluster/identitygovernance/v1beta1/zz_generated.resolvers.go
+++ b/apis/cluster/identitygovernance/v1beta1/zz_generated.resolvers.go
@@ -41,7 +41,7 @@ func (mg *PrivilegedAccessGroupAssignmentSchedule) ResolveReferences(ctx context
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.PrincipalID),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.ForProvider.PrincipalIDRef,
 		Selector:     mg.Spec.ForProvider.PrincipalIDSelector,
@@ -75,7 +75,7 @@ func (mg *PrivilegedAccessGroupAssignmentSchedule) ResolveReferences(ctx context
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.PrincipalID),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.InitProvider.PrincipalIDRef,
 		Selector:     mg.Spec.InitProvider.PrincipalIDSelector,

--- a/apis/cluster/identitygovernance/v1beta1/zz_privilegedaccessgroupassignmentschedule_types.go
+++ b/apis/cluster/identitygovernance/v1beta1/zz_privilegedaccessgroupassignmentschedule_types.go
@@ -52,7 +52,7 @@ type PrivilegedAccessGroupAssignmentScheduleInitParameters struct {
 	// The Object ID of the principal to be assigned to the above group. Can be either a user or a group.
 	// The ID of the Principal assigned to the schedule
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/cluster/users/v1beta1.User
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	PrincipalID *string `json:"principalId,omitempty" tf:"principal_id,omitempty"`
 
 	// Reference to a User in users to populate principalId.
@@ -171,7 +171,7 @@ type PrivilegedAccessGroupAssignmentScheduleParameters struct {
 	// The Object ID of the principal to be assigned to the above group. Can be either a user or a group.
 	// The ID of the Principal assigned to the schedule
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/cluster/users/v1beta1.User
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	// +kubebuilder:validation:Optional
 	PrincipalID *string `json:"principalId,omitempty" tf:"principal_id,omitempty"`
 

--- a/apis/cluster/identitygovernance/v1beta1/zz_privilegedaccessgroupassignmentschedule_types.go
+++ b/apis/cluster/identitygovernance/v1beta1/zz_privilegedaccessgroupassignmentschedule_types.go
@@ -30,7 +30,7 @@ type PrivilegedAccessGroupAssignmentScheduleInitParameters struct {
 	// The Object ID of the Azure AD group to which the principal will be assigned.
 	// The ID of the Group representing the scope of the assignment
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/cluster/groups/v1beta2.Group
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	GroupID *string `json:"groupId,omitempty" tf:"group_id,omitempty"`
 
 	// Reference to a Group in groups to populate groupId.
@@ -146,7 +146,7 @@ type PrivilegedAccessGroupAssignmentScheduleParameters struct {
 	// The Object ID of the Azure AD group to which the principal will be assigned.
 	// The ID of the Group representing the scope of the assignment
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/cluster/groups/v1beta2.Group
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	// +kubebuilder:validation:Optional
 	GroupID *string `json:"groupId,omitempty" tf:"group_id,omitempty"`
 

--- a/apis/cluster/identitygovernance/v1beta1/zz_privilegedaccessgroupeligibilityschedule_types.go
+++ b/apis/cluster/identitygovernance/v1beta1/zz_privilegedaccessgroupeligibilityschedule_types.go
@@ -52,7 +52,7 @@ type PrivilegedAccessGroupEligibilityScheduleInitParameters struct {
 	// The Object ID of the principal to be assigned to the above group. Can be either a user or a group.
 	// The ID of the Principal assigned to the schedule
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/cluster/users/v1beta1.User
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	PrincipalID *string `json:"principalId,omitempty" tf:"principal_id,omitempty"`
 
 	// Reference to a User in users to populate principalId.
@@ -171,7 +171,7 @@ type PrivilegedAccessGroupEligibilityScheduleParameters struct {
 	// The Object ID of the principal to be assigned to the above group. Can be either a user or a group.
 	// The ID of the Principal assigned to the schedule
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/cluster/users/v1beta1.User
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	// +kubebuilder:validation:Optional
 	PrincipalID *string `json:"principalId,omitempty" tf:"principal_id,omitempty"`
 

--- a/apis/cluster/identitygovernance/v1beta1/zz_privilegedaccessgroupeligibilityschedule_types.go
+++ b/apis/cluster/identitygovernance/v1beta1/zz_privilegedaccessgroupeligibilityschedule_types.go
@@ -30,7 +30,7 @@ type PrivilegedAccessGroupEligibilityScheduleInitParameters struct {
 	// The Object ID of the Azure AD group to which the principal will be assigned.
 	// The ID of the Group representing the scope of the assignment
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/cluster/groups/v1beta2.Group
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	GroupID *string `json:"groupId,omitempty" tf:"group_id,omitempty"`
 
 	// Reference to a Group in groups to populate groupId.
@@ -146,7 +146,7 @@ type PrivilegedAccessGroupEligibilityScheduleParameters struct {
 	// The Object ID of the Azure AD group to which the principal will be assigned.
 	// The ID of the Group representing the scope of the assignment
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/cluster/groups/v1beta2.Group
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	// +kubebuilder:validation:Optional
 	GroupID *string `json:"groupId,omitempty" tf:"group_id,omitempty"`
 

--- a/apis/namespaced/identitygovernance/v1beta1/zz_generated.resolvers.go
+++ b/apis/namespaced/identitygovernance/v1beta1/zz_generated.resolvers.go
@@ -7,7 +7,6 @@ package v1beta1
 
 import (
 	"context"
-
 	reference "github.com/crossplane/crossplane-runtime/v2/pkg/reference"
 	resource "github.com/crossplane/upjet/v2/pkg/resource"
 	errors "github.com/pkg/errors"
@@ -42,7 +41,7 @@ func (mg *PrivilegedAccessGroupAssignmentSchedule) ResolveReferences(ctx context
 
 	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.PrincipalID),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.ForProvider.PrincipalIDRef,
 		Selector:     mg.Spec.ForProvider.PrincipalIDSelector,
@@ -76,7 +75,7 @@ func (mg *PrivilegedAccessGroupAssignmentSchedule) ResolveReferences(ctx context
 
 	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.PrincipalID),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.InitProvider.PrincipalIDRef,
 		Selector:     mg.Spec.InitProvider.PrincipalIDSelector,

--- a/apis/namespaced/identitygovernance/v1beta1/zz_generated.resolvers.go
+++ b/apis/namespaced/identitygovernance/v1beta1/zz_generated.resolvers.go
@@ -24,7 +24,7 @@ func (mg *PrivilegedAccessGroupAssignmentSchedule) ResolveReferences(ctx context
 
 	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.GroupID),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.ForProvider.GroupIDRef,
 		Selector:     mg.Spec.ForProvider.GroupIDSelector,
@@ -58,7 +58,7 @@ func (mg *PrivilegedAccessGroupAssignmentSchedule) ResolveReferences(ctx context
 
 	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.GroupID),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.InitProvider.GroupIDRef,
 		Selector:     mg.Spec.InitProvider.GroupIDSelector,
@@ -102,7 +102,7 @@ func (mg *PrivilegedAccessGroupEligibilitySchedule) ResolveReferences(ctx contex
 
 	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.GroupID),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.ForProvider.GroupIDRef,
 		Selector:     mg.Spec.ForProvider.GroupIDSelector,
@@ -136,7 +136,7 @@ func (mg *PrivilegedAccessGroupEligibilitySchedule) ResolveReferences(ctx contex
 
 	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.GroupID),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.InitProvider.GroupIDRef,
 		Selector:     mg.Spec.InitProvider.GroupIDSelector,

--- a/apis/namespaced/identitygovernance/v1beta1/zz_generated.resolvers.go
+++ b/apis/namespaced/identitygovernance/v1beta1/zz_generated.resolvers.go
@@ -7,6 +7,7 @@ package v1beta1
 
 import (
 	"context"
+
 	reference "github.com/crossplane/crossplane-runtime/v2/pkg/reference"
 	resource "github.com/crossplane/upjet/v2/pkg/resource"
 	errors "github.com/pkg/errors"
@@ -119,7 +120,7 @@ func (mg *PrivilegedAccessGroupEligibilitySchedule) ResolveReferences(ctx contex
 
 	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.PrincipalID),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.ForProvider.PrincipalIDRef,
 		Selector:     mg.Spec.ForProvider.PrincipalIDSelector,
@@ -153,7 +154,7 @@ func (mg *PrivilegedAccessGroupEligibilitySchedule) ResolveReferences(ctx contex
 
 	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.PrincipalID),
-		Extract:      resource.ExtractResourceID(),
+		Extract:      resource.ExtractParamPath("object_id", true),
 		Namespace:    mg.GetNamespace(),
 		Reference:    mg.Spec.InitProvider.PrincipalIDRef,
 		Selector:     mg.Spec.InitProvider.PrincipalIDSelector,

--- a/apis/namespaced/identitygovernance/v1beta1/zz_privilegedaccessgroupassignmentschedule_types.go
+++ b/apis/namespaced/identitygovernance/v1beta1/zz_privilegedaccessgroupassignmentschedule_types.go
@@ -31,7 +31,7 @@ type PrivilegedAccessGroupAssignmentScheduleInitParameters struct {
 	// The Object ID of the Azure AD group to which the principal will be assigned.
 	// The ID of the Group representing the scope of the assignment
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/namespaced/groups/v1beta1.Group
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	GroupID *string `json:"groupId,omitempty" tf:"group_id,omitempty"`
 
 	// Reference to a Group in groups to populate groupId.
@@ -147,7 +147,7 @@ type PrivilegedAccessGroupAssignmentScheduleParameters struct {
 	// The Object ID of the Azure AD group to which the principal will be assigned.
 	// The ID of the Group representing the scope of the assignment
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/namespaced/groups/v1beta1.Group
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	// +kubebuilder:validation:Optional
 	GroupID *string `json:"groupId,omitempty" tf:"group_id,omitempty"`
 

--- a/apis/namespaced/identitygovernance/v1beta1/zz_privilegedaccessgroupassignmentschedule_types.go
+++ b/apis/namespaced/identitygovernance/v1beta1/zz_privilegedaccessgroupassignmentschedule_types.go
@@ -53,7 +53,7 @@ type PrivilegedAccessGroupAssignmentScheduleInitParameters struct {
 	// The Object ID of the principal to be assigned to the above group. Can be either a user or a group.
 	// The ID of the Principal assigned to the schedule
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/namespaced/users/v1beta1.User
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	PrincipalID *string `json:"principalId,omitempty" tf:"principal_id,omitempty"`
 
 	// Reference to a User in users to populate principalId.
@@ -172,7 +172,7 @@ type PrivilegedAccessGroupAssignmentScheduleParameters struct {
 	// The Object ID of the principal to be assigned to the above group. Can be either a user or a group.
 	// The ID of the Principal assigned to the schedule
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/namespaced/users/v1beta1.User
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	// +kubebuilder:validation:Optional
 	PrincipalID *string `json:"principalId,omitempty" tf:"principal_id,omitempty"`
 

--- a/apis/namespaced/identitygovernance/v1beta1/zz_privilegedaccessgroupeligibilityschedule_types.go
+++ b/apis/namespaced/identitygovernance/v1beta1/zz_privilegedaccessgroupeligibilityschedule_types.go
@@ -31,7 +31,7 @@ type PrivilegedAccessGroupEligibilityScheduleInitParameters struct {
 	// The Object ID of the Azure AD group to which the principal will be assigned.
 	// The ID of the Group representing the scope of the assignment
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/namespaced/groups/v1beta1.Group
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	GroupID *string `json:"groupId,omitempty" tf:"group_id,omitempty"`
 
 	// Reference to a Group in groups to populate groupId.
@@ -147,7 +147,7 @@ type PrivilegedAccessGroupEligibilityScheduleParameters struct {
 	// The Object ID of the Azure AD group to which the principal will be assigned.
 	// The ID of the Group representing the scope of the assignment
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/namespaced/groups/v1beta1.Group
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	// +kubebuilder:validation:Optional
 	GroupID *string `json:"groupId,omitempty" tf:"group_id,omitempty"`
 

--- a/apis/namespaced/identitygovernance/v1beta1/zz_privilegedaccessgroupeligibilityschedule_types.go
+++ b/apis/namespaced/identitygovernance/v1beta1/zz_privilegedaccessgroupeligibilityschedule_types.go
@@ -53,7 +53,7 @@ type PrivilegedAccessGroupEligibilityScheduleInitParameters struct {
 	// The Object ID of the principal to be assigned to the above group. Can be either a user or a group.
 	// The ID of the Principal assigned to the schedule
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/namespaced/users/v1beta1.User
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	PrincipalID *string `json:"principalId,omitempty" tf:"principal_id,omitempty"`
 
 	// Reference to a User in users to populate principalId.
@@ -172,7 +172,7 @@ type PrivilegedAccessGroupEligibilityScheduleParameters struct {
 	// The Object ID of the principal to be assigned to the above group. Can be either a user or a group.
 	// The ID of the Principal assigned to the schedule
 	// +crossplane:generate:reference:type=github.com/upbound/provider-azuread/apis/namespaced/users/v1beta1.User
-	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractResourceID()
+	// +crossplane:generate:reference:extractor=github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)
 	// +kubebuilder:validation:Optional
 	PrincipalID *string `json:"principalId,omitempty" tf:"principal_id,omitempty"`
 

--- a/config/cluster/identitygovernance/config.go
+++ b/config/cluster/identitygovernance/config.go
@@ -29,5 +29,9 @@ func Configure(p *config.Provider) {
 			TerraformName: "azuread_group",
 			Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)`,
 		}
+		r.References["principal_id"] = config.Reference{
+			TerraformName: "azuread_user",
+			Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)`,
+		}
 	})
 }

--- a/config/cluster/identitygovernance/config.go
+++ b/config/cluster/identitygovernance/config.go
@@ -15,11 +15,19 @@ func Configure(p *config.Provider) {
 		// this resource, which would be "identitygovernance"
 		r.ShortGroup = group
 		r.Kind = "PrivilegedAccessGroupAssignmentSchedule"
+		r.References["group_id"] = config.Reference{
+			TerraformName: "azuread_group",
+			Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)`,
+		}
 	})
 	p.AddResourceConfigurator("azuread_privileged_access_group_eligibility_schedule", func(r *config.Resource) {
 		// We need to override the default group that upjet generated for
 		// this resource, which would be "identitygovernance"
 		r.ShortGroup = group
 		r.Kind = "PrivilegedAccessGroupEligibilitySchedule"
+		r.References["group_id"] = config.Reference{
+			TerraformName: "azuread_group",
+			Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)`,
+		}
 	})
 }

--- a/config/cluster/identitygovernance/config.go
+++ b/config/cluster/identitygovernance/config.go
@@ -19,6 +19,10 @@ func Configure(p *config.Provider) {
 			TerraformName: "azuread_group",
 			Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)`,
 		}
+		r.References["principal_id"] = config.Reference{
+			TerraformName: "azuread_user",
+			Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)`,
+		}
 	})
 	p.AddResourceConfigurator("azuread_privileged_access_group_eligibility_schedule", func(r *config.Resource) {
 		// We need to override the default group that upjet generated for

--- a/config/namespaced/identitygovernance/config.go
+++ b/config/namespaced/identitygovernance/config.go
@@ -29,5 +29,9 @@ func Configure(p *config.Provider) {
 			TerraformName: "azuread_group",
 			Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)`,
 		}
+		r.References["principal_id"] = config.Reference{
+			TerraformName: "azuread_user",
+			Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)`,
+		}
 	})
 }

--- a/config/namespaced/identitygovernance/config.go
+++ b/config/namespaced/identitygovernance/config.go
@@ -15,11 +15,19 @@ func Configure(p *config.Provider) {
 		// this resource, which would be "identitygovernance"
 		r.ShortGroup = group
 		r.Kind = "PrivilegedAccessGroupAssignmentSchedule"
+		r.References["group_id"] = config.Reference{
+			TerraformName: "azuread_group",
+			Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)`,
+		}
 	})
 	p.AddResourceConfigurator("azuread_privileged_access_group_eligibility_schedule", func(r *config.Resource) {
 		// We need to override the default group that upjet generated for
 		// this resource, which would be "identitygovernance"
 		r.ShortGroup = group
 		r.Kind = "PrivilegedAccessGroupEligibilitySchedule"
+		r.References["group_id"] = config.Reference{
+			TerraformName: "azuread_group",
+			Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)`,
+		}
 	})
 }

--- a/config/namespaced/identitygovernance/config.go
+++ b/config/namespaced/identitygovernance/config.go
@@ -19,6 +19,10 @@ func Configure(p *config.Provider) {
 			TerraformName: "azuread_group",
 			Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)`,
 		}
+		r.References["principal_id"] = config.Reference{
+			TerraformName: "azuread_user",
+			Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("object_id",true)`,
+		}
 	})
 	p.AddResourceConfigurator("azuread_privileged_access_group_eligibility_schedule", func(r *config.Resource) {
 		// We need to override the default group that upjet generated for


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #250
This PR adds extractors to azuread_group refs in following resources:
* `PrivilegedAccessGroupAssignmentSchedule` for `spec.forProvider.groupId(Ref | Selector)`
* `PrivilegedAccessGroupEligibilitySchedule` for `spec.forProvider.groupId(Ref | Selector)`
Change was required after update of terraform provider as Group's `id` has been changed from `object-id-uuid` to `/groups/object-id-uuid`

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
I'm not able to test the code as PrivilegedAccessGroup resources require AAD Premium Licence.
Please run E2E tests for:
* `examples/cluster/identitygovernance/v1beta1/privilegedaccessgroupassignmentschedule.yaml`
* `examples/cluster/identitygovernance/v1beta1/privilegedaccessgroupeligibilityschedule.yaml`

[contribution process]: https://git.io/fj2m9
